### PR TITLE
created endpoint that restrict sellers to only view orders

### DIFF
--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -48,4 +48,15 @@ export class OrderController {
   async getAllOrders() {
     return this.orderService.getAllOrders();
   }
+
+  // endpoint that allows sellers to fetch their orders
+  @Get('seller/:sellerId')
+@UseGuards(JwtAuthGuard)
+async getSellerOrders(@Param('sellerId') sellerId: number, @Request() req) {
+  if (req.user.id !== sellerId && req.user.role !== UserRole.ADMIN) {
+    throw new ForbiddenException('You are not authorized to view these orders.');
+  }
+  return this.orderService.getSellerOrders(sellerId);
+}
+
 }

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -69,4 +69,16 @@ export class OrderService {
       order: { id: 'DESC' },
     });
   }
+
+  // filter orders based on the seller’s products.
+  async getSellerOrders(sellerId: number): Promise<Order[]> {
+    return await this.orderRepository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.orderItems', 'orderItem')
+      .leftJoinAndSelect('orderItem.product', 'product')
+      .where('product.sellerId = :sellerId', { sellerId })
+      .orderBy('order.createdAt', 'DESC')
+      .getMany();
+  }
+  
 }


### PR DESCRIPTION
this endpoint ensures proper access control while allowing sellers to track sales by.
Summary:
This query fetches orders where the sellerId matches the seller of the products in the order.
Sellers can only access orders containing their products.
Admins can fetch all orders.